### PR TITLE
DRM時系列データの表示

### DIFF
--- a/src/components/Map/Layer/temporalLayerMaker.ts
+++ b/src/components/Map/Layer/temporalLayerMaker.ts
@@ -281,16 +281,16 @@ class TripsDRMLayerCreator extends TemporalLayerCreator {
         data: layerConfig.source,
         // @ts-ignore
         getLineColor: (d: any) => {
-          const dataIndex: number = Math.trunc(timestamp / layerConfig.step) - 1;
+          const dataIndex: number = Math.trunc(timestamp / layerConfig.step);
           const temporalValue: number = JSON.parse(d.properties.traffic_volume)[dataIndex];
-
+console.log(dataIndex);
           // 0〜1の範囲にノーマライズの計算
           const normalizedValue = this.generateNormalizedValue(temporalValue, layerConfig);
           return this.generateColor(normalizedValue, layerConfig);
         },
         // 線幅の表示
         getLineWidth: (d: any) => {
-          const dataIndex: number = Math.trunc(timestamp / layerConfig.step) - 1;
+          const dataIndex: number = Math.trunc(timestamp / layerConfig.step);
           const temporalValue: number = JSON.parse(d.properties.traffic_volume)[dataIndex];
           const normalizedValue = this.generateNormalizedValue(temporalValue, layerConfig);
           const widths = layerConfig.widths || [5, 5];

--- a/src/components/Map/Layer/temporalLayerMaker.ts
+++ b/src/components/Map/Layer/temporalLayerMaker.ts
@@ -73,7 +73,36 @@ abstract class TemporalLayerCreator {
   extractTargetConfig() {
     return this.layerConfig.filter((layer) => layer.type === this.layerType);
   }
-}
+
+  /**
+   * 値をlayerConfig.valuesの値とでnormalizeする
+   */
+  generateNormalizedValue(value, layerConfig) {
+    return Math.max(
+      0,
+      Math.min(
+        1,
+        (value - layerConfig.values[0]) /
+          (layerConfig.values[1] - layerConfig.values[0])
+      )
+    );
+  }
+
+  /**
+   * layerConfig.colorsの値からcolorを生成する
+   */
+  generateColor(value, layerConfig): RGBAColor{
+    const [r1, g1, b1, a1] = layerConfig.colors[0];
+    const [r2, g2, b2, a2] = layerConfig.colors[1];
+    return [
+      r1 * (1 - value) + r2 * value,
+      g1 * (1 - value) + g2 * value,
+      b1 * (1 - value) + b2 * value,
+      a1 * (1 - value) + a2 * value,
+    ];
+  }
+
+ }
 
 class BusTripLayerCreator extends TemporalLayerCreator {
   layerType: TemporalLayerType = 'bus_trip';
@@ -142,23 +171,9 @@ class TemporalPolygonLayerCreator extends TemporalLayerCreator {
           const normalizedTimestamp = timestamp - (timestamp % d.properties.step);
           const temporalValue: number =
             d.properties[String(normalizedTimestamp).padStart(2, '0')] || 0;
-          const normalizedValue = Math.max(
-            0,
-            Math.min(
-              1,
-              (temporalValue - layerConfig.values[0]) /
-                (layerConfig.values[1] - layerConfig.values[0])
-            )
-          );
-          const [r1, g1, b1, a1] = layerConfig.colors[0];
-          const [r2, g2, b2, a2] = layerConfig.colors[1];
-          const color: RGBAColor = [
-            r1 * (1 - normalizedValue) + r2 * normalizedValue,
-            g1 * (1 - normalizedValue) + g2 * normalizedValue,
-            b1 * (1 - normalizedValue) + b2 * normalizedValue,
-            a1 * (1 - normalizedValue) + a2 * normalizedValue,
-          ];
-          return color;
+
+          const normalizedValue = this.generateNormalizedValue(temporalValue, layerConfig);
+          return this.generateColor(normalizedValue, layerConfig);
         },
         getElevation: (d: any) => {
           const normalizedTimestamp = timestamp - (timestamp % d.properties.step);
@@ -203,36 +218,16 @@ class TemporalLineLayerCreator extends TemporalLayerCreator {
           const normalizedTimestamp = timestamp - (timestamp % d.properties.step);
           const temporalValue: number =
             d.properties[String(normalizedTimestamp).padStart(2, '0')] || 0;
-          const normalizedValue = Math.max(
-            0,
-            Math.min(
-              1,
-              (temporalValue - layerConfig.values[0]) /
-                (layerConfig.values[1] - layerConfig.values[0])
-            )
-          );
-          const [r1, g1, b1, a1] = layerConfig.colors[0];
-          const [r2, g2, b2, a2] = layerConfig.colors[1];
-          const color: RGBAColor = [
-            r1 * (1 - normalizedValue) + r2 * normalizedValue,
-            g1 * (1 - normalizedValue) + g2 * normalizedValue,
-            b1 * (1 - normalizedValue) + b2 * normalizedValue,
-            a1 * (1 - normalizedValue) + a2 * normalizedValue,
-          ];
-          return color;
+
+          const normalizedValue = this.generateNormalizedValue(temporalValue, layerConfig);
+          return this.generateColor(normalizedValue, layerConfig);
         },
         getLineWidth: (d: any) => {
           const normalizedTimestamp = timestamp - (timestamp % d.properties.step);
           const temporalValue: number =
             d.properties[String(normalizedTimestamp).padStart(2, '0')] || 0;
-          const normalizedValue = Math.max(
-            0,
-            Math.min(
-              1,
-              (temporalValue - layerConfig.values[0]) /
-                (layerConfig.values[1] - layerConfig.values[0])
-            )
-          );
+
+          const normalizedValue = this.generateNormalizedValue(temporalValue, layerConfig);
           const widths = layerConfig.widths || [5, 5];
           const width = widths[0] * (1 - normalizedValue) + widths[1] * normalizedValue;
           return width;
@@ -273,8 +268,6 @@ class TripsJsonLayerCreator extends TemporalLayerCreator {
     return result;
   }
 }
-
-// DRMデータの時系列表示対応
 class TripsDRMLayerCreator extends TemporalLayerCreator {
   // レイヤータイプは'trips_drm'
   layerType: TemporalLayerType = 'trips_drm';
@@ -287,47 +280,19 @@ class TripsDRMLayerCreator extends TemporalLayerCreator {
         id: layerConfig.id,
         data: layerConfig.source,
         // @ts-ignore
-        // 色の表示
         getLineColor: (d: any) => {
-
-          // dataの取得
           const dataIndex: number = Math.trunc(timestamp / layerConfig.step) - 1;
           const temporalValue: number = JSON.parse(d.properties.traffic_volume)[dataIndex];
 
           // 0〜1の範囲にノーマライズの計算
-          // このあたり、他の時系列表現で同じ処理が多いのでまとめるのを検討
-          const normalizedValue = Math.max(
-            0,
-            Math.min(
-              1,
-              (temporalValue - layerConfig.values[0]) /
-                (layerConfig.values[1] - layerConfig.values[0])
-            )
-          );
-          // 色の決定
-          const [r1, g1, b1, a1] = layerConfig.colors[0];
-          const [r2, g2, b2, a2] = layerConfig.colors[1];
-          const color: RGBAColor = [
-            r1 * (1 - normalizedValue) + r2 * normalizedValue,
-            g1 * (1 - normalizedValue) + g2 * normalizedValue,
-            b1 * (1 - normalizedValue) + b2 * normalizedValue,
-            a1 * (1 - normalizedValue) + a2 * normalizedValue,
-          ];
-
-          return color;
+          const normalizedValue = this.generateNormalizedValue(temporalValue, layerConfig);
+          return this.generateColor(normalizedValue, layerConfig);
         },
         // 線幅の表示
         getLineWidth: (d: any) => {
           const dataIndex: number = Math.trunc(timestamp / layerConfig.step) - 1;
           const temporalValue: number = JSON.parse(d.properties.traffic_volume)[dataIndex];
-          const normalizedValue = Math.max(
-            0,
-            Math.min(
-              1,
-              (temporalValue - layerConfig.values[0]) /
-                (layerConfig.values[1] - layerConfig.values[0])
-            )
-          );
+          const normalizedValue = this.generateNormalizedValue(temporalValue, layerConfig);
           const widths = layerConfig.widths || [5, 5];
           const width = widths[0] * (1 - normalizedValue) + widths[1] * normalizedValue;
           return width;
@@ -340,7 +305,6 @@ class TripsDRMLayerCreator extends TemporalLayerCreator {
         updateTriggers: {
           getLineColor: [timestamp],
           getLineWidth: [timestamp],
-          currentTime: [timestamp],
         },
       });
       return mLayer;

--- a/src/components/Map/Layer/temporalLayerMaker.ts
+++ b/src/components/Map/Layer/temporalLayerMaker.ts
@@ -274,8 +274,9 @@ class TripsJsonLayerCreator extends TemporalLayerCreator {
   }
 }
 
-
+// DRMデータの時系列表示対応
 class TripsDRMLayerCreator extends TemporalLayerCreator {
+  // レイヤータイプは'trips_drm'
   layerType: TemporalLayerType = 'trips_drm';
 
   makeDeckGlLayers(init, timestamp: number) {
@@ -286,6 +287,7 @@ class TripsDRMLayerCreator extends TemporalLayerCreator {
         id: layerConfig.id,
         data: layerConfig.source,
         // @ts-ignore
+        // 色の表示
         getLineColor: (d: any) => {
 
           // dataの取得
@@ -293,6 +295,7 @@ class TripsDRMLayerCreator extends TemporalLayerCreator {
           const temporalValue: number = JSON.parse(d.properties.traffic_volume)[dataIndex];
 
           // 0〜1の範囲にノーマライズの計算
+          // このあたり、他の時系列表現で同じ処理が多いのでまとめるのを検討
           const normalizedValue = Math.max(
             0,
             Math.min(
@@ -313,6 +316,7 @@ class TripsDRMLayerCreator extends TemporalLayerCreator {
 
           return color;
         },
+        // 線幅の表示
         getLineWidth: (d: any) => {
           const dataIndex: number = Math.trunc(timestamp / layerConfig.step) - 1;
           const temporalValue: number = JSON.parse(d.properties.traffic_volume)[dataIndex];
@@ -328,6 +332,7 @@ class TripsDRMLayerCreator extends TemporalLayerCreator {
           const width = widths[0] * (1 - normalizedValue) + widths[1] * normalizedValue;
           return width;
         },
+        // 最低5Pixcl幅で表示
         lineWidthMinPixels: 5,
         visible: init && this.isChecked(layerConfig),
         stroked: false,

--- a/src/components/Map/Layer/temporalLayerMaker.ts
+++ b/src/components/Map/Layer/temporalLayerMaker.ts
@@ -283,7 +283,6 @@ class TripsDRMLayerCreator extends TemporalLayerCreator {
         getLineColor: (d: any) => {
           const dataIndex: number = Math.trunc(timestamp / layerConfig.step);
           const temporalValue: number = JSON.parse(d.properties.traffic_volume)[dataIndex];
-console.log(dataIndex);
           // 0〜1の範囲にノーマライズの計算
           const normalizedValue = this.generateNormalizedValue(temporalValue, layerConfig);
           return this.generateColor(normalizedValue, layerConfig);


### PR DESCRIPTION
## Issue
Close #14

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
- DRM時系列データの時系列表示

## テスト:Test
<!-- 手動で動作確認する必要があるなら記載 -->
- メニューの一番下にDRMのテストデータ表示できる設定が入っている
- DRM時系列データが表示される

## その他:Notes
<!-- 重点的に見てほしい点など、何かあれば書く -->
- config.jsonでの設定についてバックエンド側とやりとりする必要あり、今回の設定で問題ないか