### PR TITLE
menuモジュールをテスト可能な構成に変更

### DIFF
--- a/src/components/LayerFilter/config.ts
+++ b/src/components/LayerFilter/config.ts
@@ -5,8 +5,7 @@ import { getMenu, getFilteredIdList } from '@/components/LayerFilter/menu';
  * 表示可能なレイヤのconfigだけ収集する
  */
 export const getFilteredLayerConfig = () => {
-  const menu = getMenu();
-  return configJson['layers'].filter((layer) => getFilteredIdList(menu).includes(layer.id));
+  return configJson['layers'].filter((layer) => getFilteredIdList(getMenu()).includes(layer.id));
 };
 
 /**

--- a/src/components/LayerFilter/config.ts
+++ b/src/components/LayerFilter/config.ts
@@ -1,11 +1,12 @@
 import configJson from '@/assets/config.json';
-import { getFilteredIdList } from '@/components/LayerFilter/menu';
+import { getMenu, getFilteredIdList } from '@/components/LayerFilter/menu';
 
 /**
  * 表示可能なレイヤのconfigだけ収集する
  */
 export const getFilteredLayerConfig = () => {
-  return configJson['layers'].filter((layer) => getFilteredIdList().includes(layer.id));
+  const menu = getMenu();
+  return configJson['layers'].filter((layer) => getFilteredIdList(menu).includes(layer.id));
 };
 
 /**

--- a/src/components/LayerFilter/menu.test.ts
+++ b/src/components/LayerFilter/menu.test.ts
@@ -1,12 +1,79 @@
-import * as menu from './menu';
+import { Menu, getFilteredIdList } from './menu';
+
+const menuJsonMock: Menu = [
+  {
+    category: '裾野市航空写真',
+    data: [
+      {
+        title: '裾野市航空写真（平成28年度）',
+        type: 'raster',
+        lng: 138.903424,
+        lat: 35.203515,
+        zoom: 14,
+        id: ['susono-arial'],
+        checked: false,
+        color: '#44a196',
+        download_url: 'https://www.geospatial.jp/ckan/dataset/susono-photo-1',
+      },
+      {
+        title: '裾野市航空写真（令和元年度）',
+        type: 'raster',
+        lng: 138.903424,
+        lat: 35.203515,
+        zoom: 12,
+        id: ['susono-arial-2020'],
+        checked: true,
+        color: '#44a196',
+        download_url: 'https://www.geospatial.jp/ckan/dataset/susono-photo-1',
+      },
+    ],
+  },
+  {
+    category: '建物',
+    data: [
+      {
+        title: 'ゼンリン三次元建物形状データ',
+        type: 'vector',
+        lng: 138.914248,
+        lat: 35.047566,
+        zoom: 14,
+        id: ['shizuoka-building'],
+        checked: true,
+        color: '#FFFFFF',
+      },
+    ],
+  },
+  {
+    category: '都市計画',
+    data: [
+      {
+        title: '居住誘導区域 (平成31年3月時点）',
+        type: 'polygon',
+        lng: 138.9067,
+        lat: 35.174,
+        zoom: 12,
+        id: ['susono-kyojyu-yudo'],
+        checked: false,
+        color: '#dca050',
+        download_url: 'https://www.geospatial.jp/ckan/dataset/yuudoukuiiki',
+      },
+      {
+        title: '都市機能誘導区域-岩波 (平成31年3月時点）',
+        type: 'polygon',
+        lng: 138.9185,
+        lat: 35.2164,
+        zoom: 14,
+        id: ['susono-toshi-kinou-yudo-iwanami'],
+        checked: false,
+        color: '#a050dc',
+        download_url: 'https://www.geospatial.jp/ckan/dataset/yuudoukuiiki',
+      },
+    ],
+  },
+];
 
 describe('test menu.ts', () => {
-  // 今のところ何の意味もないテスト
-  test('test functions', () => {
-    expect(menu.getMenu()).toHaveLength(24);
-  });
-
   test('getFilterdLayer', () => {
-    expect(menu.getFilteredIdList()).toHaveLength(90);
+    expect(getFilteredIdList(menuJsonMock)).toHaveLength(90);
   });
 });

--- a/src/components/LayerFilter/menu.test.ts
+++ b/src/components/LayerFilter/menu.test.ts
@@ -74,6 +74,6 @@ const menuJsonMock: Menu = [
 
 describe('test menu.ts', () => {
   test('getFilterdLayer', () => {
-    expect(getFilteredIdList(menuJsonMock)).toHaveLength(90);
+    expect(getFilteredIdList(menuJsonMock)).toHaveLength(5);
   });
 });

--- a/src/components/LayerFilter/sideBar.ts
+++ b/src/components/LayerFilter/sideBar.ts
@@ -23,7 +23,7 @@ export const getCheckedLayerIdByDataTitleList = (layerTitleList: string[]) => {
     // 最後にチェックされたレイヤのidを取得するため反転
     const reverseLayerTitleList = [...layerTitleList];
     for (const layerTitle of reverseLayerTitleList.reverse()) {
-      const idList = getIdByDataTitle(layerTitle);
+      const idList = getIdByDataTitle(getMenu(), layerTitle);
       if (havingLegendIdList.includes(idList[0])) {
         return idList[0];
       }
@@ -36,6 +36,6 @@ export const getCheckedLayerIdByDataTitleList = (layerTitleList: string[]) => {
  * menu.jsonの中でchecked=trueのdataのみ返す
  */
 export const filterCheckedData = () =>
-  getDataList().filter((data) => {
+  getDataList(getMenu()).filter((data) => {
     return data.checked === true;
   });

--- a/src/components/Map/Controller/TimeSlider.tsx
+++ b/src/components/Map/Controller/TimeSlider.tsx
@@ -13,7 +13,7 @@ import { context } from '@/pages';
 import Slider from 'react-rangeslider';
 import { Deck } from 'deck.gl';
 import { getFilteredLayerConfig } from '@/components/LayerFilter/config';
-import { getDataList } from '@/components/LayerFilter/menu';
+import { getDataList, getMenu } from '@/components/LayerFilter/menu';
 import { addRenderOption } from '@/components/Map/Layer/renderOption';
 import { makeTemporalLayers, TEMPORAL_LAYER_TYPES } from '../Layer/temporalLayerMaker';
 import maplibregl from 'maplibre-gl';
@@ -57,7 +57,7 @@ export const TimeSlider: VFC<Props> = memo(function TimeSlider({ map, deck, setT
 
   const getLayerConfig = () => {
     return getFilteredLayerConfig().filter((layer) => {
-      return getDataList().some(
+      return getDataList(getMenu()).some(
         (value) => value.id.includes(layer.id) && TEMPORAL_LAYER_TYPES.includes(layer.type)
       );
     });

--- a/src/components/Map/Layer/deckGlLayerFactory.ts
+++ b/src/components/Map/Layer/deckGlLayerFactory.ts
@@ -9,7 +9,7 @@ import { getFilteredLayerConfig } from '@/components/LayerFilter/config';
 import { makeIconLayers } from '@/components/Map/Layer/iconLayerMaker';
 import { Dispatch, SetStateAction } from 'react';
 import { Deck } from 'deck.gl';
-import { getDataList } from '@/components/LayerFilter/menu';
+import { getDataList, getMenu } from '@/components/LayerFilter/menu';
 import { makeTile3DLayers } from '@/components/Map/Layer/tile3DLayerMaker';
 
 export const makeDeckGlLayers = (
@@ -36,7 +36,7 @@ export const makeDeckGlLayers = (
   // ここでフィルタリングのidを求める
   const layerConfig = getFilteredLayerConfig().filter((layer) => {
     // check状態になっているものを取り出し
-    return getDataList().some((value) => value.checked && value.id.includes(layer.id));
+    return getDataList(getMenu()).some((value) => value.checked && value.id.includes(layer.id));
   });
   layerCreator.forEach((func) => {
     addRenderOption(func(map, layerConfig, true, setTooltipData)).forEach(LayerLoader);
@@ -45,7 +45,7 @@ export const makeDeckGlLayers = (
   // 初期表示のレイヤーのロード完了を検知する方法がないため1sec初期表示以外のレイヤーのロードを遅らせる
   setTimeout(() => {
     const layerConfig = getFilteredLayerConfig().filter((layer) => {
-      return getDataList().some((value) => !value.checked && value.id.includes(layer.id));
+      return getDataList(getMenu()).some((value) => !value.checked && value.id.includes(layer.id));
     });
     layerCreator.forEach((func) => {
       addRenderOption(func(map, layerConfig, false, setTooltipData)).forEach(LayerLoader);

--- a/src/components/Map/Layer/temporalLayerMaker.ts
+++ b/src/components/Map/Layer/temporalLayerMaker.ts
@@ -15,7 +15,7 @@ export const TEMPORAL_LAYER_TYPES: Array<TemporalLayerType | string> = [
 import { IconLayer, GeoJsonLayer } from '@deck.gl/layers';
 import { RGBAColor, TripsLayer } from 'deck.gl';
 import { MVTLayer } from '@deck.gl/geo-layers';
-import { getDataList } from '@/components/LayerFilter/menu';
+import { getDataList, getMenu } from '@/components/LayerFilter/menu';
 
 /**
  * 時系列アニメーションDeckGLレイヤーを作成する
@@ -62,7 +62,7 @@ abstract class TemporalLayerCreator {
 
   isChecked(layerConfig) {
     // レイヤーがチェックされているか判定
-    const dataList = getDataList();
+    const dataList = getDataList(getMenu());
     let flag = false;
     for (const data of dataList) {
       if (data.id.includes(layerConfig.id)) {

--- a/src/components/Map/Layer/visibly.ts
+++ b/src/components/Map/Layer/visibly.ts
@@ -1,4 +1,4 @@
-import { filterIds, getDataList } from '@/components/LayerFilter/menu';
+import { getMenu, filterIds, getDataList } from '@/components/LayerFilter/menu';
 import { filterLayerName } from '@/components/LayerFilter/layer';
 
 /**
@@ -6,7 +6,7 @@ import { filterLayerName } from '@/components/LayerFilter/layer';
  * @param selectedResourceNameList
  */
 const getVisiblyLayerIdList = (selectedResourceNameList: string[]) => {
-  return filterLayerName(getDataList(), selectedResourceNameList)
+  return filterLayerName(getDataList(getMenu()), selectedResourceNameList)
     .map((resource) => resource.id)
     .flat();
 };
@@ -18,7 +18,7 @@ const getVisiblyLayerIdList = (selectedResourceNameList: string[]) => {
  */
 export function toggleVisibly(originalLayers: any[], targetLayerIdList: string[]) {
   // チェックボックスがオンになっている確認可能なidのリストを作成
-  const visibleLayerIdList = filterIds(getVisiblyLayerIdList(targetLayerIdList));
+  const visibleLayerIdList = filterIds(getMenu(), getVisiblyLayerIdList(targetLayerIdList));
 
   //上記リストでdeck.glの可視状態を変更したレイヤーの配列を返す
   return originalLayers.map((layer: any) => {

--- a/src/components/Map/Legend/Content/title.tsx
+++ b/src/components/Map/Legend/Content/title.tsx
@@ -1,4 +1,4 @@
-import { getDataTitleById } from '@/components/LayerFilter/menu';
+import { getDataTitleById, getMenu } from '@/components/LayerFilter/menu';
 
 type props = {
   id: string;
@@ -6,6 +6,6 @@ type props = {
 
 export const Title = (props: props) => {
   const { id } = props;
-  const title = getDataTitleById(id);
+  const title = getDataTitleById(getMenu(), id);
   return <p className="text-center font-bold">{title}</p>;
 };

--- a/src/components/Map/Legend/index.tsx
+++ b/src/components/Map/Legend/index.tsx
@@ -3,7 +3,7 @@ import { context } from '@/pages';
 import Content from '@/components/Map/Legend/Content';
 import { clickedLayerViewState } from '@/components/Map/types';
 import { havingLegendIdList } from '@/components/Map/Legend/layerIds';
-import { getDataTitleById } from '@/components/LayerFilter/menu';
+import { getDataTitleById, getMenu } from '@/components/LayerFilter/menu';
 import { getCheckedLayerIdByDataTitleList } from '@/components/LayerFilter/sideBar';
 import { defaultLegendId } from '@/components/Map/Legend/layerIds';
 
@@ -31,7 +31,7 @@ export const useGetClickedLayerId = () => {
   // 現在凡例が表示されている場合、そのタイトルを取得
   let displayedLegendLayerTitle = '';
   if (displayedLegendLayerId !== '') {
-    displayedLegendLayerTitle = getDataTitleById(displayedLegendLayerId);
+    displayedLegendLayerTitle = getDataTitleById(getMenu(), displayedLegendLayerId);
   }
   // 初回にこの関数が呼ばれた際は何も返さない
   if (isDefault) {

--- a/src/components/SideBar/Content/Layers.tsx
+++ b/src/components/SideBar/Content/Layers.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect } from 'react';
 import { context } from '@/pages';
 import { resource } from '@/components/Map/types';
 import { getResourceIcon } from '@/components/SideBar/Icon';
-import { getDataById } from '@/components/LayerFilter/menu';
+import { getDataById, getMenu } from '@/components/LayerFilter/menu';
 import { filterCheckedData } from '@/components/LayerFilter/sideBar';
 import { DownloadIcon } from '@/components/SideBar/Icon';
 
@@ -11,7 +11,7 @@ const isSelected = (resourceName: string, selectedResourceNameList: string[]): b
 };
 
 const setResourceViewState = (resourceId: string[], setClickedLayerViewState: any) => {
-  const targetResource = getDataById(resourceId);
+  const targetResource = getDataById(getMenu(), resourceId);
 
   setClickedLayerViewState({
     longitude: targetResource.lng,

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -8,7 +8,7 @@ import { getMenu, getFilterdLayer } from '@/components/LayerFilter/menu';
 
 const Sidebar: React.FC = () => {
   const [InputFilterKeyword, setInputFilterKeyword] = useState('');
-  const filterContents = getFilterdLayer(InputFilterKeyword);
+  const filterContents = getFilterdLayer(getMenu(), InputFilterKeyword);
   const visiblyContentList = getVisiblyContent(filterContents);
 
   return (


### PR DESCRIPTION
- 関数群からなるmenuモジュールは、`getMenu()`というJSONを読み込む関数に他の全ての関数が依存しており、テストが出来ない状態だったため、Menuデータを渡して各種フィルター処理などを行うよう、リファクタリングしました。
- JSONから読み込んだオブジェクトに型を定義しました。