### PR TITLE
同一のオブジェクトに対する語彙の揺れを統一

### DIFF
--- a/src/components/LayerFilter/layer.ts
+++ b/src/components/LayerFilter/layer.ts
@@ -1,11 +1,11 @@
-import { resource } from '@/components/Map/types';
+import { Data } from '@/components/LayerFilter/menu';
 
 /**
  * サイドバーのチェックボックスがonになっているレイヤだけ収集する
  * @param dataList
  * @param selectedResourceNameList
  */
-export const filterLayerName = (dataList: resource[], selectedResourceNameList: string[]) =>
+export const filterLayerName = (dataList: Data[], selectedResourceNameList: string[]) =>
   dataList.filter((resource) => {
     const resourceName = resource.title;
     return selectedResourceNameList.includes(resourceName);

--- a/src/components/LayerFilter/menu.ts
+++ b/src/components/LayerFilter/menu.ts
@@ -1,7 +1,12 @@
 import menuJson from '../../assets/menu.json';
 
 type DataType = 'raster' | 'vector' | 'polygon' | 'line' | 'point' | 'building' | 'icon';
-type Data = {
+
+/**
+ * menu.json直下のFolderがもつレイヤー定義
+ * menu.json内ではdata:Data[]として配列で保持されている
+ */
+export type Data = {
   title: string;
   type: DataType;
   lng: number;
@@ -14,14 +19,21 @@ type Data = {
   download_url?: string;
 };
 
-type Category = {
+/**
+ * menu.json直下の各要素
+ * Folderはメタデータのほかdata: Data[]として子要素の配列を持つ
+ */
+type Folder = {
   category: string;
   url?: string;
   open?: boolean;
   data: Data[];
 };
 
-export type Menu = Category[];
+/**
+ * menu.jsonの構造と一致する型
+ */
+export type Menu = Folder[];
 
 /**
  * menu.jsonを返す
@@ -100,7 +112,7 @@ export const getFilteredMenu = (menu: Menu, inputFilterKeyword: String): Menu =>
     });
 
     if (filteredData.length > 0) {
-      const filteredCategory: Category = { ...category }; // DeepCopy
+      const filteredCategory: Folder = { ...category }; // DeepCopy
       filteredCategory.data = filteredData;
       filteredMenu.push(filteredCategory);
     }

--- a/src/components/SideBar/Content/Layers.tsx
+++ b/src/components/SideBar/Content/Layers.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import { context } from '@/pages';
-import { resource } from '@/components/Map/types';
+import { Data } from '@/components/LayerFilter/menu';
 import { getResourceIcon } from '@/components/SideBar/Icon';
 import { getDataById, getMenu } from '@/components/LayerFilter/menu';
 import { filterCheckedData } from '@/components/LayerFilter/sideBar';
@@ -26,7 +26,7 @@ const getDefaultVisiblyLayerTitles = () => {
 };
 
 type LayersProps = {
-  layers: resource[];
+  layers: Data[];
 };
 
 export const Layers = (props: LayersProps) => {

--- a/src/components/SideBar/Icon/index.tsx
+++ b/src/components/SideBar/Icon/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { resource } from '@/components/Map/types';
+import { Data } from '@/components/LayerFilter/menu';
 
 const getIconSize = () => {
   return {
@@ -156,7 +156,7 @@ const BuildingIcon = (color: string) => {
   );
 };
 
-export const getResourceIcon = (resource: resource) => {
+export const getResourceIcon = (resource: Data) => {
   const color = resource.color;
 
   const type = resource.type;

--- a/src/components/SideBar/types.ts
+++ b/src/components/SideBar/types.ts
@@ -1,6 +1,0 @@
-import { resource } from '@/components/Map/types';
-
-export type VisibleContent = {
-  dataset: string;
-  layers: resource[];
-};


### PR DESCRIPTION
- menu.json内のdataという要素はData[]という型を当てていたが、別のところで`resource`という名前がつけられていたので統一。挙動に変化はありません。
- menu.json直下の各要素を`Category`から`Folder`に（Categoryという型名の要素にcategoryというstring要素があり読みづらい）
※型定義だけでなく変数名にも揺れがあるのですが(dataList,layers,resource)、こちらは「挙動が変わってしまう可能性がある」という観点から今回は触っていません。