### PR TITLE
MapLibreのControlを前面に

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,4 @@
+.maplibregl-control-container {
+    position: inherit;
+    z-index: 10;
+}


### PR DESCRIPTION
close #29 

タイトルのとおり
ボタンでズームレベルを操作すると、DeckGLの見た目の更新が少し遅れます（これはしかたない）