### PR TITLE
SideBarの初回レンダリング時に、初期チェックボックスが正しく描画されていない不具合の修正

### DIFF
--- a/src/components/SideBar/Content/Layers.tsx
+++ b/src/components/SideBar/Content/Layers.tsx
@@ -2,7 +2,10 @@ import React, { Dispatch, FC, SetStateAction, useCallback, useContext, useEffect
 import { context } from '@/pages';
 import { Data, Menu } from '@/components/LayerFilter/menu';
 import { getResourceIcon } from '@/components/SideBar/Icon';
-import { filterCheckedData } from '@/components/LayerFilter/sideBar';
+import {
+  filterCheckedData,
+  getCheckedLayerIdByDataTitleList,
+} from '@/components/LayerFilter/sideBar';
 import { DownloadIcon } from '@/components/SideBar/Icon';
 import { useRecoilState } from 'recoil';
 import { LayersState, TemporalLayerConfigState } from '@/store/LayersState';
@@ -71,6 +74,7 @@ export const Layers: FC<LayersProps> = ({ layers }) => {
       setDeckGLLayers,
     ]
   );
+
   //最初の一度だけ、menuのcheckedを確認し、trueならcheckedLayerTitleListにset
   useEffect(() => {
     layers
@@ -78,13 +82,6 @@ export const Layers: FC<LayersProps> = ({ layers }) => {
       .forEach((value) => {
         layerCreateById(value.id);
       });
-    setCheckedLayerTitleList(
-      layers
-        .filter((value) => value.checked)
-        .map((value) => {
-          return value.title;
-        })
-    );
   }, []);
 
   const toggleSelectedResourceList = (resource: Data) => {

--- a/src/components/SideBar/Content/Layers.tsx
+++ b/src/components/SideBar/Content/Layers.tsx
@@ -75,7 +75,7 @@ export const Layers: FC<LayersProps> = ({ layers }) => {
     ]
   );
 
-  //最初の一度だけ、menuのcheckedを確認し、trueならcheckedLayerTitleListにset
+  //最初の一度だけ、menuのcheckedを確認し、trueならレイヤーを作成する
   useEffect(() => {
     layers
       .filter((value) => value.checked)

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -1,5 +1,5 @@
 import { context } from '@/pages';
-import React, { useState, useContext, Dispatch, SetStateAction } from 'react';
+import React, { useState, useContext, Dispatch, SetStateAction, useEffect } from 'react';
 import { getVisiblyContent } from '@/components/LayerFilter/sideBar';
 import { Content } from '@/components/SideBar/Content';
 import { Layers } from '@/components/SideBar/Content/Layers';
@@ -7,10 +7,25 @@ import { FilterLayerInput } from '@/components/SideBar/Content/FilterLayerInput'
 import { getFilteredMenu } from '@/components/LayerFilter/menu';
 
 const Sidebar: React.FC = () => {
-  const { preferences } = useContext(context);
+  const { setCheckedLayerTitleList, preferences } = useContext(context);
   const [InputFilterKeyword, setInputFilterKeyword] = useState('');
   const filteredMenu = getFilteredMenu(preferences.menu, InputFilterKeyword);
   const visiblyContentList = getVisiblyContent(filteredMenu);
+
+  const layers = visiblyContentList.flatMap((content) => {
+    return content.layers;
+  });
+
+  // 初回レンダリング時にチェック済のレイヤータイトルを設定しておく
+  useEffect(() => {
+    setCheckedLayerTitleList(
+      layers
+        .filter((value) => value.checked)
+        .map((value) => {
+          return value.title;
+        })
+    );
+  }, []);
 
   return (
     <>

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -12,14 +12,13 @@ const Sidebar: React.FC = () => {
   const filteredMenu = getFilteredMenu(preferences.menu, InputFilterKeyword);
   const visiblyContentList = getVisiblyContent(filteredMenu);
 
-  const layers = visiblyContentList.flatMap((content) => {
-    return content.layers;
-  });
-
   // 初回レンダリング時にチェック済のレイヤータイトルを設定しておく
   useEffect(() => {
     setCheckedLayerTitleList(
-      layers
+      visiblyContentList
+        .flatMap((content) => {
+          return content.layers;
+        })
         .filter((value) => value.checked)
         .map((value) => {
           return value.title;


### PR DESCRIPTION
# 概要
SideBarの初回レンダリング時に、初期チェックボックスが正しく描画されていない不具合を修正した

# エラー内容
サイドバーの初期表示時にチェックボックスが反映されていない

チェックボックスに対応するレイヤーは正しく初期表示されていることから、
サイドバーのチェックボックスに関わるUIのみが不具合を起こしていると考えられる

国道などのレイヤーが表示されているのにも関わらず、サイドバーにはチェックが入っていない
![image](https://user-images.githubusercontent.com/20750714/205229785-f9f32c13-f5d3-48c1-bbee-e372ce2c4d6e.png)

# 原因
`SideBar/Content/Layers`コンポーネントにて初回レンダリング時に、チェックボックスのチェック状態を設定していたのが原因。

`SideBar/Content/Layers.tsx`コンポーネントは、サイドバーのカテゴリ内のレイヤーを表すコンポーネントであり、
このコンポーネント内で、サイドバー全体のチェック状態を設定(setCheckedLayerTitleList)していた。

Layersコンポーネントは、カテゴリの数だけ作成され、それぞれが初回レンダリングを行うため、
setCheckedLayerTitleListは、以前のレイヤー名をすべて破棄し、カテゴリの初期チェックボックスがtrueであるレイヤー名のみ設定してしまう。

その結果、最後のカテゴリしかチェックが行われなくなり、初期チェックボックスが正しく描画されていないようになっていた。

# 修正
カテゴリより上のコンポーネントで、サイドバー全体のチェック状態を設定する。
サイドバー全体を司るコンポーネントは、`SideBar/index.tsx`なので、このコンポーネントの初回レンダリング時に、サイドバー全体のチェック状態を設定する
