### PR TITLE
データクリック時のマーカードロップを削除

### DIFF
--- a/src/components/Map/Layer/arcLayerMaker.ts
+++ b/src/components/Map/Layer/arcLayerMaker.ts
@@ -29,8 +29,6 @@ class ArcLayerCreator {
   private layerType: string = 'Arc';
   private readonly layerConfig: any;
   setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;

--- a/src/components/Map/Layer/deckGlLayerFactory.ts
+++ b/src/components/Map/Layer/deckGlLayerFactory.ts
@@ -16,8 +16,6 @@ import { SetterOrUpdater } from 'recoil';
 export const makeDeckGLLayer = (
   layerConfig: LayerConfig,
   setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;

--- a/src/components/Map/Layer/geoJsonLayerMaker.ts
+++ b/src/components/Map/Layer/geoJsonLayerMaker.ts
@@ -41,8 +41,6 @@ class GeoJsonLinePolygonCreator {
   layerType: string = 'geojson';
   private readonly layerConfig: LayerConfig;
   private readonly setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;
@@ -91,8 +89,6 @@ class GeoJsonIconLayerCreator {
   layerType: string = 'geojsonicon';
   private readonly layerConfig: LayerConfig;
   private readonly setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;
@@ -169,8 +165,6 @@ class GeoJsonFeatureCollectionIconLayerCreator {
   layerType: string = 'geojsonfcicon';
   private readonly layerConfig: LayerConfig;
   private readonly setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;

--- a/src/components/Map/Layer/iconLayerMaker.ts
+++ b/src/components/Map/Layer/iconLayerMaker.ts
@@ -25,8 +25,6 @@ class IconLayerCreator {
   private readonly layerConfig: any;
   private readonly layerType: string = 'icon';
   private readonly setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;

--- a/src/components/Map/Layer/mvtLayerMaker.ts
+++ b/src/components/Map/Layer/mvtLayerMaker.ts
@@ -30,8 +30,6 @@ class MvtLayerCreator {
   private readonly layerConfig: any;
   private readonly layerType: string = 'mvt';
   private readonly setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;

--- a/src/components/Map/Layer/tile3DLayerMaker.ts
+++ b/src/components/Map/Layer/tile3DLayerMaker.ts
@@ -25,8 +25,6 @@ class Tile3DLayerCreator {
   private readonly layerConfig: any;
   private readonly layerType: string = '3dtiles';
   private readonly setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;

--- a/src/components/Map/Layer/tileLayerMaker.ts
+++ b/src/components/Map/Layer/tileLayerMaker.ts
@@ -26,8 +26,6 @@ class tileLayerCreator {
   private readonly layerConfig: any;
   private readonly layerType: string = 'raster';
   private readonly setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 
-import { Map, Marker, NavigationControl, Style } from 'maplibre-gl';
+import { Map, NavigationControl, Style } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import { Deck, FlyToInterpolator } from '@deck.gl/core/typed';
@@ -14,7 +14,7 @@ import { TimeSlider } from '@/components/Map/Controller/TimeSlider';
 import { getLayerConfigById } from '@/components/LayerFilter/config';
 import { Backgrounds, Preferences } from '@/components/LayerFilter/loader';
 import DashboardPanelManager from '../Dashboard/DashboardPanelManager';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import {
   DashboardLayersState,
   LayersState,
@@ -22,8 +22,6 @@ import {
   TemporalLayerState,
   WeatherMapLayerState,
 } from '@/store/LayersState';
-import { TooltipDataState } from '@/store/TooltipState';
-import { getPropertiesObj } from '@/components/Tooltip/util';
 import { ViewState } from '@/store/ViewState';
 import WeatherMapPanel from './Custom/WeatherMapPanel';
 import { useRouter } from 'next/router';
@@ -127,25 +125,6 @@ const useInitializeMap = (
   };
 };
 
-const useShowTooltip = (map: any) => {
-  const pointMarkerRef = useRef<any>();
-
-  const tooltipData = useRecoilValue(TooltipDataState);
-  useEffect(() => {
-    if (!tooltipData || !tooltipData.data) {
-      if (pointMarkerRef.current) {
-        pointMarkerRef.current.remove();
-      }
-    } else {
-      const { data, tooltipType, id, lat, lng } = tooltipData;
-      getPropertiesObj(data, !tooltipType ? 'default' : tooltipType, id);
-      if (map) {
-        pointMarkerRef.current = new Marker().setLngLat([lng, lat]).addTo(map);
-      }
-    }
-  }, [map, tooltipData]);
-};
-
 const useDeckGLLayer = (currentZoomLevel: number, config) => {
   const deckglLayers = useRecoilValue(LayersState);
   const temporalLayers = useRecoilValue(TemporalLayerState);
@@ -196,7 +175,6 @@ const MapComponent: React.VFC = () => {
     deckGLRef.current.setProps({ layers: [...deckglLayers, ...dashboardLayers, weatherMapLayer] });
   }
 
-  useShowTooltip(mapRef.current);
   const router = useRouter();
 
   useEffect(() => {

--- a/src/components/Tooltip/show.ts
+++ b/src/components/Tooltip/show.ts
@@ -5,8 +5,6 @@ import { PickInfo } from 'deck.gl';
 export const showToolTip = (
   info: PickInfo<any>,
   setTooltipData: SetterOrUpdater<{
-    lng: number;
-    lat: number;
     tooltipType: 'default' | 'thumbnail' | 'table';
     id: string;
     data: any;
@@ -50,8 +48,6 @@ export const showToolTip = (
   });
   const data = getPropertiesObj(object, tooltipType, id);
   setTooltipData({
-    lng: coordinate[0],
-    lat: coordinate[1],
     tooltipType,
     id,
     data,

--- a/src/store/TooltipState.ts
+++ b/src/store/TooltipState.ts
@@ -1,8 +1,6 @@
 import { atom } from 'recoil';
 
 export const TooltipDataState = atom<{
-  lng: number;
-  lat: number;
   tooltipType: 'default' | 'thumbnail' | 'table';
   id: string;
   data: any;


### PR DESCRIPTION
## 変更内容
- Markerドロップ用のHookを削除
- RecoilのTooltipDataのStateからlat/lngを削除