### PR TITLE
テストコードの静的エラーを解消した

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@testing-library/dom": "^8.14.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "12.1.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.2.1",
     "@types/jest": "^28.1.3",
     "@types/react": "17.0.17",

--- a/src/components/Header/index.test.tsx
+++ b/src/components/Header/index.test.tsx
@@ -1,11 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import React from 'react';
+import React, { SetStateAction, useState } from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import Header from '.';
 import { context } from '@/pages';
+import { Disasters, Preferences } from '../LayerFilter/loader';
 
 jest.mock('@/components/Map', () => {
   return function DummyPages(props) {
@@ -27,9 +28,20 @@ describe('Rendering', () => {
   };
   _context.preferences = { settings: mockSettings };
   it('title in json', () => {
+    const disasters: Disasters = {
+      default: 1,
+      data: [],
+    };
+    const [_preference, setPreferrence] = useState<Preferences | null>(null);
+    const [_currentDisaster, setCurrentDisaster] = useState<string>('');
     const header = render(
       <context.Provider value={_context}>
-        <Header />
+        <Header
+          disasters={disasters}
+          isDisaster={true}
+          setPreferrence={setPreferrence}
+          setCurrentDisaster={setCurrentDisaster}
+        />
       </context.Provider>
     );
 

--- a/src/components/Header/index.test.tsx
+++ b/src/components/Header/index.test.tsx
@@ -4,6 +4,7 @@
 import React, { SetStateAction, useState } from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { renderHook, cleanup } from '@testing-library/react-hooks';
 import Header from '.';
 import { context } from '@/pages';
 import { Disasters, Preferences } from '../LayerFilter/loader';
@@ -21,6 +22,9 @@ jest.mock('@/components/Tooltip/content', () => {
 });
 
 describe('Rendering', () => {
+  beforeEach(() => {
+    cleanup();
+  });
   const _context: any = {};
   const mockSettings = {
     title: 'デジタル裾野',
@@ -32,14 +36,22 @@ describe('Rendering', () => {
       default: 1,
       data: [],
     };
-    const [_preference, setPreferrence] = useState<Preferences | null>(null);
-    const [_currentDisaster, setCurrentDisaster] = useState<string>('');
+    const {
+      result: {
+        current: [_preferences, setPreferences],
+      },
+    } = renderHook(() => useState<Preferences | null>(null));
+    const {
+      result: {
+        current: [_currentDisaster, setCurrentDisaster],
+      },
+    } = renderHook(() => useState<string>(''));
     const header = render(
       <context.Provider value={_context}>
         <Header
           disasters={disasters}
           isDisaster={true}
-          setPreferrence={setPreferrence}
+          setPreferrence={setPreferences}
           setCurrentDisaster={setCurrentDisaster}
         />
       </context.Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,6 +1263,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@12.1.2":
   version "12.1.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
@@ -5798,6 +5806,13 @@ react-draggable@^4.4.5:
   dependencies:
     clsx "^1.1.1"
     prop-types "^15.8.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^3.0.1:
   version "3.2.0"


### PR DESCRIPTION
テストコード`src/compoonents/Header/index.test.tsx`が静的エラーになっていたので、修正しました。

Headerタグの引数が不足していたので、適当な値を入れてテストを通過させています。
```tsx
    const disasters: Disasters = {
      default: 1,
      data: [],
    };
    const {
      result: {
        current: [_preferences, setPreferences],
      },
    } = renderHook(() => useState<Preferences | null>(null));
    const {
      result: {
        current: [_currentDisaster, setCurrentDisaster],
      },
    } = renderHook(() => useState<string>(''));
    const header = render(
      <context.Provider value={_context}>
        <Header
          disasters={disasters}
          isDisaster={true}
          setPreferrence={setPreferrence}
          setCurrentDisaster={setCurrentDisaster}
        />
      </context.Provider>
    );
```

# 追記
jest中にhookを利用するためのライブラリ `@testing-library/react-hooks`を導入しました。
上記ライブラリを利用してjest中でhookを利用しています。